### PR TITLE
Add Task Delegation Agent prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,8 @@ Shyjal
 
 
 
+
+## Related Documentation
+
+For a prototype delegator and architecture overview see [docs/task-delegation-architecture.md](docs/task-delegation-architecture.md).
+

--- a/docs/task-delegation-architecture.md
+++ b/docs/task-delegation-architecture.md
@@ -1,0 +1,31 @@
+# AI Task Delegation Agent (AITDA)
+
+This document outlines a conceptual architecture for an AI agent that delegates tasks between different AI models, external APIs, and human reviewers.
+
+## System Overview
+
+1. **Input Layer** – Accepts user requests in text, voice, or structured formats. Performs basic preprocessing such as normalization and entity extraction.
+2. **Context Analyzer** – Detects intent, classifies complexity, assesses urgency, and determines sensitivity.
+3. **Task Planner and Orchestrator** – Central logic that decides whether to route tasks to AI models, external APIs, or humans. Provides fallback strategies when confidence is low.
+4. **Delegation Targets**
+   - **AI Models** – LLMs for text, vision models for images, or speech models for audio tasks.
+   - **External APIs** – Data sources, transactional services, or search APIs.
+   - **Human Input** – For judgment‑heavy or sensitive requests.
+
+A simplified decision flow is illustrated below using Mermaid syntax.
+
+```mermaid
+graph TD;
+    A[New Task] --> B{Sensitive?};
+    B -- Yes --> H[Assign to Human];
+    B -- No --> C{Complexity};
+    C -- Low --> D{Needs External Data?};
+    D -- Yes --> E[Call API];
+    D -- No --> F[Use AI Model];
+    C -- Medium --> G[Hybrid Approach];
+    C -- High --> H;
+```
+
+## Prototype Logic
+
+The accompanying file `src/taskDelegationAgent.js` includes a minimal prototype demonstrating how such a delegator might be structured in JavaScript.

--- a/src/taskDelegationAgent.js
+++ b/src/taskDelegationAgent.js
@@ -1,0 +1,49 @@
+/**
+ * Minimal prototype for an AI Task Delegation Agent (AITDA).
+ * This example focuses on the decision logic used to route tasks
+ * to AI models, external APIs, or human reviewers.
+ */
+class TaskDelegationAgent {
+  constructor(models = {}, apis = {}, humanHandler = null) {
+    this.models = models; // e.g., { llm: async () => {...} }
+    this.apis = apis;     // e.g., { weather: async () => {...} }
+    this.humanHandler = humanHandler; // function(task)
+  }
+
+  // Analyze context, complexity, urgency, and sensitivity
+  analyze(task) {
+    return {
+      complexity: typeof task === 'string' && task.length < 50 ? 'low' : 'medium',
+      urgency: 'normal',
+      sensitivity: task.toLowerCase().includes('legal') ? 'high' : 'low',
+    };
+  }
+
+  async delegate(task) {
+    const context = this.analyze(task);
+
+    if (context.sensitivity === 'high' && this.humanHandler) {
+      return this.humanHandler(task);
+    }
+
+    if (context.complexity === 'low' && this.models.llm) {
+      return this.models.llm(task);
+    }
+
+    if (context.complexity === 'medium' && this.apis.search) {
+      const apiResult = await this.apis.search(task);
+      if (apiResult?.confidence > 0.8) {
+        return apiResult;
+      }
+    }
+
+    // Fallback to human-in-the-loop if available
+    if (this.humanHandler) {
+      return this.humanHandler(task);
+    }
+
+    throw new Error('No suitable delegation target found');
+  }
+}
+
+export default TaskDelegationAgent;


### PR DESCRIPTION
## Summary
- document an AI Task Delegation Agent design using Mermaid
- prototype minimal delegation logic in `src/taskDelegationAgent.js`
- link the new documentation from the main README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840307c6668832b8f04ecf8a2d76091